### PR TITLE
[Develop] Modal props, Sidebar style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fave-ui",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "React UI KiT by Fave",
   "author": "Fave",
   "license": "MIT",

--- a/src/Layout/style.css
+++ b/src/Layout/style.css
@@ -16,7 +16,7 @@
       }
 
       & > .ant-typography {
-        @apply ml-2 font-semibold text-slate-700 whitespace-nowrap;
+        @apply ml-2 font-semibold text-slate-700 whitespace-nowrap overflow-hidden text-ellipsis;
       }
 
       &-button {

--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -57,22 +57,22 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
+        closable,
+        closeIcon,
+        width
+      })
       : originalFunctions.error({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        closable,
+        closeIcon,
+        width
+      })
   },
   warning: ({
     closeIcon = defaultCloseIcon,
@@ -84,22 +84,22 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
+        closable,
+        closeIcon,
+        width
+      })
       : originalFunctions.warning({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        closable,
+        closeIcon,
+        width
+      })
   },
   info: ({
     closeIcon = defaultCloseIcon,
@@ -111,22 +111,22 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
+        closable,
+        closeIcon,
+        width
+      })
       : originalFunctions.info({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        closable,
+        closeIcon,
+        width
+      })
   }
 }
 

--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -1,35 +1,32 @@
-import * as React from 'react';
-import {
-  Modal as AntModal,
-  ModalFuncProps as AntModalFuncProps,
-  ModalProps as AntModalProps
-} from 'antd';
-import classNames from 'classnames';
+import * as React from 'react'
+import { Modal as AntModal, ModalFuncProps as AntModalFuncProps, ModalProps as AntModalProps } from 'antd'
+import classNames from 'classnames'
 
-import { X, Info, WarningCircle, XCircle } from 'phosphor-react';
+import { X, Info, WarningCircle, XCircle } from 'phosphor-react'
 
-import Button from '../Button';
+import Button from '../Button'
 
-import './style.css';
+import './style.css'
 
 export type ModalProps = AntModalProps & {
-  icon?: React.ReactNode;
-  confirmMode?: boolean;
-  modalFunc: (args: ModalFuncProps) => void;
-};
+  icon?: React.ReactNode
+  confirmMode?: boolean
+  modalFunc: (args: ModalFuncProps) => void
+}
 
 export type ModalFuncProps = AntModalFuncProps & {
-  hasIcon?: boolean;
-  confirmMode?: boolean;
-};
+  hasIcon?: boolean
+  confirmMode?: boolean
+}
 
 const getClassName = ({ className, hasIcon }: ModalFuncProps) => {
-  return classNames(className, hasIcon ? 'with-icon' : '');
-};
+  return classNames(className, hasIcon ? 'with-icon' : '')
+}
 
-const defaultCloseIcon = <X size={16} />;
+const defaultWidth = 352
+const defaultCloseIcon = <X size={16} />
 
-const originalFunctions = { ...AntModal };
+const originalFunctions = { ...AntModal }
 
 export const ModalFunctions = {
   confirm: ({
@@ -37,95 +34,104 @@ export const ModalFunctions = {
     closable = true,
     icon,
     hasIcon,
+    width = defaultWidth,
     ...restProps
   }: ModalFuncProps) => {
     return originalFunctions.confirm({
       ...restProps,
       className: getClassName(restProps),
       icon: hasIcon ? icon : null,
-      cancelButtonProps: { className: 'ant-btn-text' },
+      cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
       closable,
-      closeIcon
-    });
+      closeIcon,
+      width
+    })
   },
   error: ({
     closeIcon = defaultCloseIcon,
     closable = true,
     icon = <XCircle size={24} color={'#DC2626'} />,
     confirmMode,
+    width = defaultWidth,
     ...restProps
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-        ...restProps,
-        className: getClassName(restProps),
-        icon: icon,
-        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-        closable,
-        closeIcon
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
+          closable,
+          closeIcon,
+          width
+        })
       : originalFunctions.error({
-        ...restProps,
-        className: getClassName(restProps),
-        icon: icon,
-        closable,
-        closeIcon
-      });
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          closable,
+          closeIcon,
+          width
+        })
   },
   warning: ({
     closeIcon = defaultCloseIcon,
     closable = true,
     icon = <WarningCircle size={24} color={'#FBBF24'} />,
     confirmMode,
+    width = defaultWidth,
     ...restProps
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-        ...restProps,
-        className: getClassName(restProps),
-        icon: icon,
-        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-        closable,
-        closeIcon
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
+          closable,
+          closeIcon,
+          width
+        })
       : originalFunctions.warning({
-        ...restProps,
-        className: getClassName(restProps),
-        icon: icon,
-        closable,
-        closeIcon
-      });
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          closable,
+          closeIcon,
+          width
+        })
   },
   info: ({
     closeIcon = defaultCloseIcon,
     closable = true,
     icon = <Info size={24} color={'#334155'} />,
     confirmMode,
+    width = defaultWidth,
     ...restProps
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-        ...restProps,
-        className: getClassName(restProps),
-        icon: icon,
-        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-        closable,
-        closeIcon
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
+          closable,
+          closeIcon,
+          width
+        })
       : originalFunctions.info({
-        ...restProps,
-        className: getClassName(restProps),
-        icon: icon,
-        closable,
-        closeIcon
-      });
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          closable,
+          closeIcon,
+          width
+        })
   }
-};
+}
 
 const Modal: React.FC<ModalProps> = props => {
-  return (
-    <Button onClick={() => props.modalFunc({ ...props })}>Press Me</Button>
-  );
-};
+  return <Button onClick={() => props.modalFunc({ ...props })}>Press Me</Button>
+}
 
-export default Modal;
+export default Modal

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -3,56 +3,44 @@
 @import '../Button/style.css';
 
 .ant-modal {
-
-  &-content{
+  &-content {
     @apply rounded-lg;
   }
 
-  &-confirm{
-    @apply w-[352px] !important;
-    .ant-modal-body{
+  &-confirm {
+    .ant-modal-body {
       @apply p-4;
     }
 
-    &-content {
-      @apply font-inter leading-5 ml-2 mr-6 mt-1 !important;
-      @apply text-neutral-700 !important;
+    &-body &-title {
+      @apply ml-2 w-72 text-neutral-700 font-bold leading-6;
     }
-  
-    &-title {
-      @apply ml-2 w-72;
-      @apply text-neutral-700 font-bold leading-6 !important;
-    }
-  
-    &-body {
-      @apply text-neutral-700 font-normal !important;
+
+    &-body &-content {
+      @apply font-inter leading-5 ml-2 mr-6 mt-1 text-neutral-700;
     }
   }
 
-  .ant-modal-confirm-btns{
+  .ant-modal-confirm-btns {
     @apply mt-4 mr-4;
 
-    .ant-btn > span{
+    .ant-btn > span {
       @apply leading-5;
     }
   }
 
-  &-close-x{
+  &-close-x {
     @apply w-4 h-4 mt-4 mr-4 leading-4;
 
-    svg{
+    svg {
       @apply text-neutral-400;
     }
   }
 }
 
-.ant-modal.with-icon{
-
-  @apply w-[376px] !important;
-
-  .ant-modal-confirm-body{
-    
-    svg{
+.ant-modal {
+  .ant-modal-confirm-body {
+    svg {
       @apply float-left mr-2;
     }
   }


### PR DESCRIPTION
# Description

Modal;
- allow passing of `width` and `cancelButtonProps`, defaultWidth is provided
- removed !important, refactor classes to properly override antd css classes

Sidebar;
- long names will be truncated and show ellipsis at the end

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings