### PR TITLE
[Develop] allow default pagination to be passed via props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fave-ui",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "React UI KiT by Fave",
   "author": "Fave",
   "license": "MIT",

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Table as AntTable, TableProps as AntTableProps } from 'antd';
 import { ColumnType } from 'antd/lib/table';
-import { SortOrder } from 'antd/lib/table/interface';
+import { SortOrder, TablePaginationConfig } from 'antd/lib/table/interface';
 import { ArrowsDownUp, CaretLeft, CaretRight, Funnel } from 'phosphor-react';
 import { itemRender } from '../Pagination';
 
@@ -17,6 +17,10 @@ export type HeaderWithSortProps<RecordType extends {}> = {
 };
 
 export const FilterIcon = <Funnel size={16} weight="light" />;
+const defaultPagination: TablePaginationConfig = {
+  position: ['bottomCenter'],
+  itemRender: itemRender(<CaretLeft size={16} />, <CaretRight size={16} />)
+}
 
 export const HeaderWithSort = <T extends {}>(props: HeaderWithSortProps<T>) => {
   const { sortColumns, title } = props;
@@ -42,7 +46,8 @@ export const HeaderWithSort = <T extends {}>(props: HeaderWithSortProps<T>) => {
 };
 
 const Table = <T extends {}>(props: TableProps<T>) => {
-  return <AntTable {...props} />;
+  const pagination = props.pagination ? { ...props.pagination, ...defaultPagination } : defaultPagination
+  return <AntTable {...props} pagination={pagination} />;
 };
 
 Table.defaultProps = {
@@ -51,10 +56,6 @@ Table.defaultProps = {
     triggerAsc: 'Sort ascending',
     cancelSort: 'Remove sorting'
   },
-  pagination: {
-    position: ['bottomCenter'],
-    itemRender: itemRender(<CaretLeft size={16} />, <CaretRight size={16} />)
-  }
 };
 
 export default Table;


### PR DESCRIPTION
# Description

- allow default pagination to be passed via props
- update package to 0.1.25

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
