### PR TITLE
[Develop] Tag component, removed hardcoded background color CSS

### DIFF
--- a/src/Tag/style.css
+++ b/src/Tag/style.css
@@ -4,7 +4,7 @@
 .ant-tag {
   @apply px-2 py-1 border-0 rounded-md text-sm font-inter;
   @apply inline-flex items-center;
-  @apply bg-neutral-100 text-neutral-900;
+  @apply text-neutral-900;
 
   &-success {
     @apply bg-green-500;


### PR DESCRIPTION
# Description
- removed hardcoded `bg-color` in CSS, could not be overridden by `color` prop values.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


# Screenshots (if applicable)

Please add appropriate screenshots.
