### PR TITLE
[Develop] refactor modal cancelButtonProps className logic

### DIFF
--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -60,25 +60,25 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          cancelButtonProps: {
-            ...restProps.cancelButtonProps,
-            className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
-          },
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        cancelButtonProps: {
+          ...restProps.cancelButtonProps,
+          className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
+        },
+        closable,
+        closeIcon,
+        width
+      })
       : originalFunctions.error({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        closable,
+        closeIcon,
+        width
+      })
   },
   warning: ({
     closeIcon = defaultCloseIcon,
@@ -90,25 +90,25 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          cancelButtonProps: {
-            ...restProps.cancelButtonProps,
-            className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
-          },
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        cancelButtonProps: {
+          ...restProps.cancelButtonProps,
+          className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
+        },
+        closable,
+        closeIcon,
+        width
+      })
       : originalFunctions.warning({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        closable,
+        closeIcon,
+        width
+      })
   },
   info: ({
     closeIcon = defaultCloseIcon,
@@ -120,25 +120,25 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          cancelButtonProps: {
-            ...restProps.cancelButtonProps,
-            className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
-          },
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        cancelButtonProps: {
+          ...restProps.cancelButtonProps,
+          className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
+        },
+        closable,
+        closeIcon,
+        width
+      })
       : originalFunctions.info({
-          ...restProps,
-          className: getClassName(restProps),
-          icon,
-          closable,
-          closeIcon,
-          width
-        })
+        ...restProps,
+        className: getClassName(restProps),
+        icon,
+        closable,
+        closeIcon,
+        width
+      })
   }
 }
 

--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -41,7 +41,10 @@ export const ModalFunctions = {
       ...restProps,
       className: getClassName(restProps),
       icon: hasIcon ? icon : null,
-      cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
+      cancelButtonProps: {
+        ...restProps.cancelButtonProps,
+        className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
+      },
       closable,
       closeIcon,
       width
@@ -57,22 +60,25 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-        ...restProps,
-        className: getClassName(restProps),
-        icon,
-        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-        closable,
-        closeIcon,
-        width
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          cancelButtonProps: {
+            ...restProps.cancelButtonProps,
+            className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
+          },
+          closable,
+          closeIcon,
+          width
+        })
       : originalFunctions.error({
-        ...restProps,
-        className: getClassName(restProps),
-        icon,
-        closable,
-        closeIcon,
-        width
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          closable,
+          closeIcon,
+          width
+        })
   },
   warning: ({
     closeIcon = defaultCloseIcon,
@@ -84,22 +90,25 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-        ...restProps,
-        className: getClassName(restProps),
-        icon,
-        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-        closable,
-        closeIcon,
-        width
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          cancelButtonProps: {
+            ...restProps.cancelButtonProps,
+            className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
+          },
+          closable,
+          closeIcon,
+          width
+        })
       : originalFunctions.warning({
-        ...restProps,
-        className: getClassName(restProps),
-        icon,
-        closable,
-        closeIcon,
-        width
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          closable,
+          closeIcon,
+          width
+        })
   },
   info: ({
     closeIcon = defaultCloseIcon,
@@ -111,22 +120,25 @@ export const ModalFunctions = {
   }: ModalFuncProps) => {
     return confirmMode === undefined || confirmMode
       ? AntModal.confirm({
-        ...restProps,
-        className: getClassName(restProps),
-        icon,
-        cancelButtonProps: { ...restProps.cancelButtonProps, className: 'ant-btn-text' },
-        closable,
-        closeIcon,
-        width
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          cancelButtonProps: {
+            ...restProps.cancelButtonProps,
+            className: classNames(restProps.cancelButtonProps?.className, 'ant-btn-text')
+          },
+          closable,
+          closeIcon,
+          width
+        })
       : originalFunctions.info({
-        ...restProps,
-        className: getClassName(restProps),
-        icon,
-        closable,
-        closeIcon,
-        width
-      })
+          ...restProps,
+          className: getClassName(restProps),
+          icon,
+          closable,
+          closeIcon,
+          width
+        })
   }
 }
 


### PR DESCRIPTION
# Description

Update the props logic for className in modal>cancelButtonProps, in order to avoid passed in className over written by className in the component itself .

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


# Screenshots (if applicable)

Please add appropriate screenshots.
